### PR TITLE
Update execution_policy.hpp

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -45,6 +45,16 @@ namespace hpx { namespace execution {
     {
     };
 
+    /// Function invocations executed by a group of parallel/vector execution 
+    /// agents are permitted to execute in unordered fashion when executed in 
+    /// different threads, and un-sequenced with respect to one another when 
+    /// executed in the same thread.
+    /// \note \a parallel_unsequenced_execution_tag is weaker than
+    ///       \a unsequenced_execution_tag.
+    struct parallel_unsequenced_execution_tag
+    {
+    };
+
     /// \cond NOINTERNAL
     struct task_policy_tag
     {

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -1301,15 +1301,15 @@ namespace hpx { namespace execution {
         /// \endcond
     };
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// The class parallel_unsequenced_policy is an execution policy type
+        ///////////////////////////////////////////////////////////////////////////
+    /// The class parallel_unsequenced_task_policy is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
     /// and indicate that a parallel algorithm's execution may be parallelized
     /// and vectorized.
-    struct parallel_unsequenced_policy
+    struct parallel_unsequenced_task_policy
     {
         /// The type of the executor associated with this execution policy
-        using executor_type = parallel_executor;
+        using executor_type = parallel_unsequenced_executor;
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
@@ -1319,26 +1319,306 @@ namespace hpx { namespace execution {
 
         /// The category of the execution agents created by this execution
         /// policy.
-        using execution_category = parallel_execution_tag;
+        using execution_category = parallel_unsequenced_execution_tag;
 
-        /// Rebind the type of executor used by this execution policy.
-        template <typename Executor, typename Parameters>
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
         struct rebind
         {
             /// The type of the rebound execution policy
-            using type = parallel_unsequenced_policy;
+            using type =
+                parallel_unsequenced_task_policy_shim<Executor_, Parameters_>;
+        };
+
+        /// \cond NOINTERNAL
+        constexpr parallel_unsequenced_task_policy() = default;
+        /// \endcond
+
+        /// Create a new parallel_unsequenced_task_policy referencing a chunk 
+        ///size.
+        /// \param tag         [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_task_policy
+        ///
+        constexpr parallel_unsequenced_task_policy operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create  a new non task parallel policy from itself
+        ///
+        /// \returns The non task parallel_unsequenced_policy
+        ///
+        inline constexpr decltype(auto) operator()(
+            non_task_policy_tag /*tag*/) const;
+
+        /// Create a new parallel_unsequenced_task_policy referencing an 
+        /// executor and a chunk size.
+        ///
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
+        ///
+        /// \returns The new parallel_unsequenced_task_policy 
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
+        {
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_task_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_task_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor()
+        {
+            return exec_;
+        }
+        /// Return the associated executor object.
+        constexpr executor_type const& executor() const
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters()
+        {
+            return params_;
+        }
+        /// Return the associated executor parameters object.
+        constexpr executor_parameters_type const& parameters() const
+        {
+            return params_;
+        }
+
+    private:
+        friend struct hpx::parallel::execution::create_rebound_policy_t;
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        constexpr void serialize(Archive&, const unsigned int)
+        {
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// The class parallel_unsequenced_task_policy_shim is an execution policy 
+    /// type used as a unique type to disambiguate parallel algorithm 
+    /// overloading and indicate that a parallel algorithm's execution may be 
+    /// parallelized and vectorized.
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_task_policy_shim
+    {
+        /// The type of the executor associated with this execution policy
+        using executor_type = parallel_unsequenced_executor;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        using executor_parameters_type =
+            parallel::execution::extract_executor_parameters<
+                executor_type>::type;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        using execution_category = parallel_unsequenced_execution_tag;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type =
+                parallel_unsequenced_task_policy_shim<Executor_, Parameters_>;
+        };
+
+        /// Create a new parallel_unsequenced_task_policy_shim referencing a  
+        /// chunk size.
+        /// \param tag         [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_task_policy
+        ///
+        constexpr parallel_unsequenced_task_policy_shim operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create  a new non task parallel unsequenced policy from itself
+        ///
+        /// \returns The non task parallel_unsequenced_policy_shim
+        ///
+        inline constexpr decltype(auto) operator()(
+            non_task_policy_tag /*tag*/) const;
+
+        /// Create a new parallel_unsequenced_task_policy_shim referencing an 
+        /// executor and a chunk size.
+        ///
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
+        ///
+        /// \returns The new parallel_unsequenced_task_policy_shim 
+        ///
+        template <typename Executor_>
+        constexpr decltype(auto) on(Executor&& exec) const
+        {
+            using executor_type = std::decay_t<Executor_>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor_, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_task_policy_shim  from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_task_policy_shim
+        ///
+        template <typename... Parameters_>
+        constexpr decltype(auto) with(Parameters_&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters_, params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor()
+        {
+            return exec_;
+        }
+        /// Return the associated executor object.
+        constexpr executor_type const& executor() const
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters()
+        {
+            return params_;
+        }
+        /// Return the associated executor parameters object.
+        constexpr executor_parameters_type const& parameters() const
+        {
+            return params_;
+        }
+
+    private:
+        friend struct hpx::parallel::execution::create_rebound_policy_t;
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        constexpr void serialize(Archive&, const unsigned int)
+        {
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// The class parallel_unsequenced_policy is an execution policy type
+    /// used as a unique type to disambiguate parallel algorithm overloading
+    /// and indicate that a parallel algorithm's execution may be parallelized
+    /// and vectorized.
+    struct parallel_unsequenced_policy
+    {
+        /// The type of the executor associated with this execution policy
+        using executor_type = parallel_unsequenced_executor;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        using executor_parameters_type =
+            parallel::execution::extract_executor_parameters<
+                executor_type>::type;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        using execution_category = parallel_unsequenced_execution_tag;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type =
+                parallel_unsequenced_policy_shim<Executor_, Parameters_>;
         };
 
         /// \cond NOINTERNAL
         constexpr parallel_unsequenced_policy() = default;
-
-        template <typename Executor, typename Parameters>
-        constexpr parallel_unsequenced_policy(Executor&&, Parameters&&) noexcept
-        {
-        }
         /// \endcond
 
-        /// Create a new non task policy from itself
+        /// Create a new parallel_unsequenced_policy referencing a chunk size.
+        ///
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        constexpr parallel_unsequenced_task_policy operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return parallel_unsequenced_task_policy();
+        }
+
+        /// Create  a new parallel_unsequenced_policy from itself
         ///
         /// \returns The non task parallel unsequenced policy
         ///
@@ -1347,13 +1627,48 @@ namespace hpx { namespace execution {
             return *this;
         }
 
-        /// Create a new task policy from itself
+         /// Create a new parallel_unsequenced_policy referencing an executor and
+        /// a chunk size.
         ///
-        /// \returns The task parallel unsequenced policy
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
         ///
-        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
         {
-            return *this;
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
         }
 
     public:
@@ -1394,9 +1709,175 @@ namespace hpx { namespace execution {
     };
 
     /// Default vector execution policy object.
-    inline constexpr parallel_unsequenced_policy par_unseq{};
+    //inline constexpr parallel_unsequenced_policy par_unseq{};
+    static constexpr parallel_unsequenced_policy par_unseq{};
 
-   
+    /// The class parallel_unsequenced_policy_shim is an execution policy type
+    /// used as a unique type to disambiguate parallel algorithm overloading
+    /// and indicate that a parallel algorithm's execution may be parallelized.
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_policy_shim
+    {
+        /// The type of the executor associated with this execution policy
+        using executor_type = std::decay_t<Executor>;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        using executor_parameters_type = std::decay_t<Parameters>;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        using execution_category =
+            typename hpx::traits::executor_execution_category<
+                executor_type>::type;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type =
+                parallel_unsequenced_policy_shim<Executor_, Parameters_>;
+        };
+
+        /// Create a new parallel_unsequenced_task_policy referencing a chunk
+        /// size.
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_task_policy_shim
+        ///
+        constexpr parallel_unsequenced_policy_shim<Executor, Parameters>
+        operator()(task_policy_tag /* tag */) const
+        {
+            return parallel_unsequenced_policy_shim<Executor, Parameters>(
+                exec_, params_);
+        }
+
+        /// Create a new parallel_policy from itself
+        ///
+        /// \param tag         [in] Specify that the corresponding asynchronous
+        ///                    execution policy should be used
+        ///
+        /// \returns The new parallel_policy
+        ///
+        constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create a new parallel_unsequenced_policy from the given
+        /// executor
+        ///
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
+        ///
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        template <typename Executor_>
+        constexpr decltype(auto) on(Executor_&& exec) const
+        {
+            using executor_type = std::decay_t<Executor_>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor_, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_policy_shim from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_policy_shim
+        ///
+        template <typename... Parameters_>
+        constexpr decltype(auto) with(Parameters_&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters_, params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor()
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor object.
+        constexpr executor_type const& executor() const
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters()
+        {
+            return params_;
+        }
+
+        /// Return the associated executor parameters object.
+        constexpr executor_parameters_type const& parameters() const
+        {
+            return params_;
+        }
+
+        /// \cond NOINTERNAL
+        template <typename Dependent = void,
+            typename Enable =
+                std::enable_if_t<std::is_constructible<Executor>::value &&
+                        std::is_constructible<Parameters>::value,
+                    Dependent>>
+        constexpr parallel_unsequenced_policy_shim()
+        {
+        }
+
+        template <typename Executor_, typename Parameters_>
+        constexpr parallel_unsequenced_policy_shim(
+            Executor_&& exec, Parameters_&& params)
+          : exec_(HPX_FORWARD(Executor_, exec))
+          , params_(HPX_FORWARD(Parameters_, params))
+        {
+        }
+
+    private:
+        friend struct hpx::parallel::execution::create_rebound_policy_t;
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int)
+        {
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+        /// \endcond
+    };
+    
     ///////////////////////////////////////////////////////////////////////////
     /// The class unsequenced_task_policy is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
@@ -1404,7 +1885,7 @@ namespace hpx { namespace execution {
     struct unsequenced_task_policy
     {
         /// The type of the executor associated with this execution policy
-        using executor_type = sequenced_executor;
+        using executor_type = unsequenced_executor;
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
@@ -1414,7 +1895,7 @@ namespace hpx { namespace execution {
 
         /// The category of the execution agents created by this execution
         /// policy.
-        using execution_category = sequenced_execution_tag;
+        using execution_category = unsequenced_execution_tag;
 
         /// Rebind the type of executor used by this execution policy.
         template <typename Executor_, typename Parameters_>
@@ -1427,29 +1908,81 @@ namespace hpx { namespace execution {
         /// \cond NOINTERNAL
         constexpr unsequenced_task_policy() = default;
                    
-        template <typename Executor, typename Parameters>
-        constexpr unsequenced_task_policy(Executor&&, Parameters&&) noexcept
-        {
-        }
-        /// \endcond
+        // template <typename Executor, typename Parameters>
+        // constexpr unsequenced_task_policy(Executor&&, Parameters&&) noexcept
+        // {
+        // }
+        // /// \endcond 
 
-        /// Create a new non task policy from itself
+        /// Create a new unsequenced_task_policy from itself
         ///
-        /// \returns The non task unsequenced task policy
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
         ///
-        constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
+        /// \returns The new unsequenced_task_policy
+        ///
+        constexpr unsequenced_task_policy const& operator()(
+            task_policy_tag /* tag */) const
         {
             return *this;
         }
 
-        /// Create a new task policy from itself
+        /// Create a corresponding non task policy for this task policy
         ///
-        /// \returns The task unsequenced task policy
+        /// \returns The non task unseqeuential policy
         ///
-        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        inline constexpr decltype(auto) operator()(
+            non_task_policy_tag /*tag*/) const;
+
+        /// Create a new unsequenced_task_policy from the given
+        /// executor
+        ///
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
+        ///
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new unsequenced_task_policy
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
         {
-            return *this;
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
         }
+
+        /// Create a new unsequenced_task_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: all parameters are executor_parameters,
+        ///                 different parameter types can't be duplicated
+        ///
+        /// \returns The new unsequenced_task_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
+        }   
 
     public:
         /// Return the associated executor object.
@@ -1488,39 +2021,6 @@ namespace hpx { namespace execution {
         executor_parameters_type params_;
     };
 
-    constexpr decltype(auto) sequenced_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return seq.on(executor()).with(parameters());
-    }
-
-    constexpr decltype(auto) parallel_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return par.on(executor()).with(parameters());
-    }
-
-    // different versions of clang-format disagree
-    // clang-format off
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-    sequenced_task_policy_shim<Executor, Parameters>::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return sequenced_task_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
-
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-    parallel_task_policy_shim<Executor, Parameters>::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return parallel_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
 
     /// Extension: The class unsequenced_task_policy_shim is an
     /// execution policy type used as a unique type to disambiguate parallel
@@ -1561,7 +2061,7 @@ namespace hpx { namespace execution {
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new unsequenced_task_policy
+        /// \returns The new unsequenced_task_policy_shim
         ///
         constexpr unsequenced_task_policy_shim const& operator()(
             task_policy_tag /* tag */) const
@@ -1571,12 +2071,12 @@ namespace hpx { namespace execution {
 
         /// Create a corresponding non task policy for this task policy
         ///
-        /// \returns The non task seqeuential shim policy
+        /// \returns The non task seqeuential policy 
         ///
         inline constexpr decltype(auto) operator()(
             non_task_policy_tag /*tag*/) const;
 
-        /// Create a new unsequenced_task_policy from the given
+        /// Create a new unsequenced_task_policy_shim from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -1588,7 +2088,7 @@ namespace hpx { namespace execution {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new unsequenced_task_policy
+        /// \returns The new unsequenced_task_policy_shim
         ///
         template <typename Executor_>
         constexpr decltype(auto) on(Executor_&& exec) const
@@ -1661,7 +2161,7 @@ namespace hpx { namespace execution {
         }
 
         template <typename Executor_, typename Parameters_>
-        constexpr sequenced_task_policy_shim(
+        constexpr unsequenced_task_policy_shim(
             Executor_&& exec, Parameters_&& params)
           : exec_(HPX_FORWARD(Executor_, exec))
           , params_(HPX_FORWARD(Parameters_, params))
@@ -1693,7 +2193,7 @@ namespace hpx { namespace execution {
     struct unsequenced_policy
     {
         /// The type of the executor associated with this execution policy
-        using executor_type = sequenced_executor;
+        using executor_type = unsequenced_executor;
 
         /// The type of the associated executor parameters object which is
         /// associated with this execution policy
@@ -1703,11 +2203,33 @@ namespace hpx { namespace execution {
 
         /// The category of the execution agents created by this execution
         /// policy.
-        using execution_category = sequenced_execution_tag;
+        using execution_category = unsequenced_execution_tag;
+
+        /// Rebind the type of executor used by this execution policy.
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type = unsequenced_task_policy_shim<Executor_, Parameters_>;
+        };
 
         /// \cond NOINTERNAL
         constexpr unsequenced_policy() = default;
-        /// \endcond
+
+        // template <typename Executor, typename Parameters>
+        // constexpr unsequenced_policy(Executor&&, Parameters&&) noexcept  
+        // {
+        // }
+        // /// \endcond
+
+        /// Create a new unsequenced_task_policy 
+        ///
+        /// \returns The new unsequenced_task_policy
+        ///
+        constexpr unsequenced_task_policy operator()(task_policy_tag /*tag*/) const
+        {
+            return unsequenced_task_policy();  
+        }
 
         /// Create a new non task policy from itself
         ///
@@ -1718,13 +2240,54 @@ namespace hpx { namespace execution {
             return *this;
         }
 
-        /// Create a new task policy from itself
+        /// Create a new unsequenced_policy from the given
+        /// executor
         ///
-        /// \returns The task unsequenced policy
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
         ///
-        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new unsequenced_policy
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
         {
-            return *this;
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
+        }
+
+        /// Create a new unsequenced_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: all parameters are executor_parameters,
+        ///                 different parameter types can't be duplicated
+        ///
+        /// \returns The new unsequenced_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
         }
 
     public:
@@ -1766,38 +2329,6 @@ namespace hpx { namespace execution {
 
     /// Default vector execution policy object.
     inline constexpr unsequenced_policy unseq{};
-
-    constexpr decltype(auto) sequenced_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return seq.on(executor()).with(parameters());
-    }
-
-    constexpr decltype(auto) parallel_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return par.on(executor()).with(parameters());
-    }
-
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-        sequenced_task_policy_shim<Executor, Parameters>::operator()(
-            non_task_policy_tag /*tag*/) const
-    {
-        return sequenced_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
-
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-        parallel_task_policy_shim<Executor, Parameters>::operator()(
-            non_task_policy_tag /*tag*/) const
-    {
-        return parallel_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
 
     /// The class unsequenced_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
@@ -1844,7 +2375,7 @@ namespace hpx { namespace execution {
 
         /// Create a new unsequenced_policy from itself.
         ///
-        /// \returns The new unsequenced_policy_shim
+        /// \returns The new non task unsequenced_policy_shim
         ///
         constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
         {
@@ -1960,6 +2491,75 @@ namespace hpx { namespace execution {
         executor_parameters_type params_;
         /// \endcond
     };
+
+    /////////////////////////////////////////////////////////////////
+    constexpr decltype(auto) sequenced_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return seq.on(executor()).with(parameters()); 
+    }
+
+    constexpr decltype(auto) parallel_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return par.on(executor()).with(parameters());
+    }
+
+    // different versions of clang-format disagree
+    // clang-format off
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    sequenced_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return sequenced_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
+
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    parallel_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return parallel_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
+    ////////////////////////////////////////////////////////////////
+    constexpr decltype(auto) unsequenced_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return unseq.on(executor()).with(parameters()); 
+    }
+
+    constexpr decltype(auto) parallel_unsequenced_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return par_unseq.on(executor()).with(parameters());
+    }
+
+    // different versions of clang-format disagree
+    // clang-format off
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    unsequenced_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return unsequenced_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
+
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    parallel_unsequenced_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return parallel_unsequenced_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
     // clang-format on
 }}    // namespace hpx::execution
 

--- a/libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp
@@ -33,15 +33,24 @@ namespace hpx { namespace execution {
 
     template <typename Executor, typename Parameters>
     struct parallel_task_policy_shim;
+
     struct unsequenced_task_policy;
 
     template <typename Executor, typename Parameters>
     struct unsequenced_task_policy_shim;
 
-    struct parallel_unsequenced_policy;
-
     struct unsequenced_policy;
 
     template <typename Executor, typename Parameters>
     struct unsequenced_policy_shim;
+
+    struct parallel_unsequenced_task_policy;
+    
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_task_policy_shim;
+
+    struct parallel_unsequenced_policy;
+    
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_policy_shim;
 }}    // namespace hpx::execution

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -398,6 +398,7 @@ namespace hpx { namespace execution {
     };
 
     using parallel_executor = parallel_policy_executor<hpx::launch>;
+    using parallel_unsequenced_executor = parallel_policy_executor<hpx::launch>;
 }}    // namespace hpx::execution
 
 namespace hpx { namespace parallel { namespace execution {

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -136,6 +136,116 @@ namespace hpx { namespace execution {
         }
         /// \endcond
     };
+    
+    ///////////////////////////////////////////////////////////////////////////
+    /// A \a unsequential_executor creates groups of unsequential execution 
+    /// agents which execute in the calling thread. 
+    ///
+    struct unsequenced_executor
+    {
+        /// \cond NOINTERNAL
+        bool operator==(unsequenced_executor const& /*rhs*/) const noexcept
+        {
+            return true;
+        }
+
+        bool operator!=(unsequenced_executor const& /*rhs*/) const noexcept
+        {
+            return false;
+        }
+
+        unsequenced_executor const& context() const noexcept
+        {
+            return *this;
+        }
+        /// \endcond
+
+        /// \cond NOINTERNAL
+        typedef unsequenced_execution_tag execution_category;
+
+        // OneWayExecutor interface
+        template <typename F, typename... Ts>
+        static
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type
+            sync_execute(F&& f, Ts&&... ts)
+        {
+            return hpx::detail::sync_launch_policy_dispatch<
+                launch::sync_policy>::call(launch::sync, HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
+        // TwoWayExecutor interface
+        template <typename F, typename... Ts>
+        static hpx::future<
+            typename hpx::util::detail::invoke_deferred_result<F, Ts...>::type>
+        async_execute(F&& f, Ts&&... ts)
+        {
+            return hpx::detail::async_launch_policy_dispatch<
+                launch::deferred_policy>::call(launch::deferred,
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        // NonBlockingOneWayExecutor (adapted) interface
+        template <typename F, typename... Ts>
+        static void post(F&& f, Ts&&... ts)
+        {
+            sync_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        // BulkTwoWayExecutor interface
+        template <typename F, typename S, typename... Ts>
+        static std::vector<hpx::future<typename parallel::execution::detail::
+                bulk_function_result<F, S, Ts...>::type>>
+        bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            typedef
+                typename parallel::execution::detail::bulk_function_result<F, S,
+                    Ts...>::type result_type;
+            std::vector<hpx::future<result_type>> results;
+
+            try
+            {
+                for (auto const& elem : shape)
+                {
+                    results.push_back(async_execute(f, elem, ts...));
+                }
+            }
+            catch (std::bad_alloc const& ba)
+            {
+                throw ba;
+            }
+            catch (...)
+            {
+                throw exception_list(std::current_exception());
+            }
+
+            return results;
+        }
+
+        template <typename F, typename S, typename... Ts>
+        static typename parallel::execution::detail::bulk_execute_result<F, S,
+            Ts...>::type
+        bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
+        {
+            return hpx::unwrap(bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
+        }
+
+        template <typename Parameters>
+        std::size_t processing_units_count(Parameters&&) const
+        {
+            return 1;
+        }
+
+    private:
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& /* ar */, const unsigned int /* version */)
+        {
+        }
+        /// \endcond
+    }; 
 }}    // namespace hpx::execution
 
 namespace hpx { namespace parallel { namespace execution {


### PR DESCRIPTION
 **Add policy:** 
unsequenced_task_policy;
unsequenced_task_policy_shim;
unsequenced_policy;
unsequenced_policy_shim;
parallel_unsequenced_task_policy;
parallel_unsequenced_task_policy_shim;
parallel_unsequenced_policy;
parallel_unsequenced_policy_shim;
    
**Update files:**
hpx/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
hpx/libs/core/executors/include/hpx/executors/parallel_executor.hpp
libs/core/execution_base/include/hpx/execution_base/execution.hpp
libs/core/executors/include/hpx/executors/sequenced_executor.hpp
libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp

**Further work(rough idea):** 

> In order to make compiler happy, add some simple definitions, but still missing implement:

add `unsequenced_executor `definition in _sequenced_executor.hpp_, may be need an extra unsequenced_executor.hpp to implement unsequenced_executor;
add `parallel_unsequenced_executor `definition in _parallel_executor.hpp_, may be need an extra unsequenced_executor.hpp to implement parallel_unsequenced_executor ;

**Remaining complain when doing local compile:**

> complain points to _value_ 

```
/home/chuanqiu/project1/new_hpx/src/hpx/libs/core/executors/include/hpx/executors/execution_policy.hpp:2254:72: error: static assertion failed: hpx::traits::is_executor_any<Executor>::value
 2254 |             static_assert(hpx::traits::is_executor_any<executor_type>::value,
```
