### PR TITLE
Compiledpass

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/handle_local_exceptions.hpp
@@ -795,8 +795,763 @@ namespace hpx { namespace parallel { namespace util { namespace detail {
     };
 
     template <>
+    struct handle_local_exceptions<
+        hpx::execution::parallel_unsequenced_task_policy>
+    {
+        ///////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        [[noreturn]] static void call(std::exception_ptr const&)
+        {
+            std::terminate();
+        }
+#else
+        [[noreturn]] static void call(std::exception_ptr const&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        [[noreturn]] static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            std::terminate();
+        }
+#else
+        [[noreturn]] static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+        static void call(std::list<std::exception_ptr>& errors)
+        {
+            if (!errors.empty())
+            {
+                parallel_exception_termination_handler();
+            }
+        }
+
+    private:
+        template <typename Future>
+        static void call_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_helper(Cont const& workitems)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::shared_future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::shared_future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::shared_future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+    private:
+        template <typename Future>
+        static void call_with_cleanup_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            hpx::future<T> const& f, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_with_cleanup_helper(Cont const& workitems)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+    };
+
+    template <typename Executor, typename Parameters>
+    struct handle_local_exceptions<
+        hpx::execution::parallel_unsequenced_policy_shim<Executor, Parameters>>
+    {
+        ///////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        [[noreturn]] static void call(std::exception_ptr const&)
+        {
+            std::terminate();
+        }
+#else
+        [[noreturn]] static void call(std::exception_ptr const&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        [[noreturn]] static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            std::terminate();
+        }
+#else
+        [[noreturn]] static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+        static void call(std::list<std::exception_ptr>& errors)
+        {
+            if (!errors.empty())
+            {
+                parallel_exception_termination_handler();
+            }
+        }
+
+    private:
+        template <typename Future>
+        static void call_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_helper(Cont const& workitems)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::shared_future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::shared_future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::shared_future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+    private:
+        template <typename Future>
+        static void call_with_cleanup_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            hpx::future<T> const& f, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_with_cleanup_helper(Cont const& workitems)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+    };
+
+    template <typename Executor, typename Parameters>
+    struct handle_local_exceptions<hpx::execution::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
+    {
+        ///////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        [[noreturn]] static void call(std::exception_ptr const&)
+        {
+            std::terminate();
+        }
+#else
+        [[noreturn]] static void call(std::exception_ptr const&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+        [[noreturn]] static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            std::terminate();
+        }
+#else
+        [[noreturn]] static void call(
+            std::exception_ptr const&, std::list<std::exception_ptr>&)
+        {
+            parallel_exception_termination_handler();
+        }
+#endif
+
+        static void call(std::list<std::exception_ptr>& errors)
+        {
+            if (!errors.empty())
+            {
+                parallel_exception_termination_handler();
+            }
+        }
+
+    private:
+        template <typename Future>
+        static void call_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+        template <typename T>
+        static void call(hpx::shared_future<T> const& f, bool = true)
+        {
+            return call_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_helper(Cont const& workitems)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T>
+        static void call(std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(std::vector<hpx::shared_future<T>> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(std::array<hpx::shared_future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T>
+        static void call(
+            std::vector<hpx::shared_future<T>> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+        template <typename T, std::size_t N>
+        static void call(
+            std::array<hpx::shared_future<T>, N> const& workitems, bool = true)
+        {
+            return call_helper(workitems);
+        }
+
+    private:
+        template <typename Future>
+        static void call_with_cleanup_helper_single(Future const& f)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(f);
+            HPX_ASSERT(false);
+#else
+            if (f.has_exception())
+            {
+                parallel_exception_termination_handler();
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(hpx::future<T> const& f,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            hpx::future<T> const& f, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper_single(f);
+        }
+
+    private:
+        template <typename Cont>
+        static void call_with_cleanup_helper(Cont const& workitems)
+        {
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+            HPX_UNUSED(workitems);
+            HPX_ASSERT(false);
+#else
+            for (auto const& f : workitems)
+            {
+                if (f.has_exception())
+                {
+                    parallel_exception_termination_handler();
+                }
+            }
+#endif
+        }
+
+    public:
+        template <typename T, typename Cleanup>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems,
+            std::list<std::exception_ptr>&, Cleanup&&, bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::vector<hpx::future<T>> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+
+        template <typename T, std::size_t N, typename Cleanup,
+            typename Enable = std::enable_if_t<!std::is_same_v<
+                std::decay_t<Cleanup>, std::list<std::exception_ptr>>>>
+        static void call_with_cleanup(
+            std::array<hpx::future<T>, N> const& workitems, Cleanup&&,
+            bool = true)
+        {
+            call_with_cleanup_helper(workitems);
+        }
+    };
+
+    template <>
     struct handle_local_exceptions<hpx::execution::unsequenced_policy>
       : handle_local_exceptions<hpx::execution::parallel_unsequenced_policy>
+    {
+    };
+
+    template <>
+    struct handle_local_exceptions<hpx::execution::unsequenced_task_policy>
+      : handle_local_exceptions<
+            hpx::execution::parallel_unsequenced_task_policy>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct handle_local_exceptions<
+        hpx::execution::unsequenced_policy_shim<Executor, Parameters>>
+      : handle_local_exceptions<hpx::execution::
+                parallel_unsequenced_policy_shim<Executor, Parameters>>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct handle_local_exceptions<
+        hpx::execution::unsequenced_task_policy_shim<Executor, Parameters>>
+      : handle_local_exceptions<hpx::execution::
+                parallel_unsequenced_task_policy_shim<Executor, Parameters>>
     {
     };
 }}}}    // namespace hpx::parallel::util::detail

--- a/libs/core/algorithms/tests/unit/algorithms/foreach.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <hpx/executors/execution_policy.hpp>
 
 #include "foreach_tests.hpp"
 
@@ -23,9 +24,13 @@ void test_for_each()
     test_for_each(seq, IteratorTag());
     test_for_each(par, IteratorTag());
     test_for_each(par_unseq, IteratorTag());
+    test_for_each(unseq, IteratorTag());
+    
 
     test_for_each_async(seq(task), IteratorTag());
     test_for_each_async(par(task), IteratorTag());
+    test_for_each_async(unseq(task), IteratorTag());
+    test_for_each_async(par_unseq(task), IteratorTag());
 }
 
 void for_each_test()

--- a/libs/core/algorithms/tests/unit/algorithms/foreach_executors.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/foreach_executors.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/local/init.hpp>
+#include <hpx/executors/execution_policy.hpp>
 
 #include <iostream>
 #include <string>
@@ -43,6 +44,9 @@ void for_each_executors_test()
 
         test_executors(par.on(exec));
         test_executors_async(par(task).on(exec));
+        
+        test_executors(par_unseq.on(exec));
+        test_executors_async(par_unseq(task).on(exec));
     }
 
     {
@@ -53,6 +57,12 @@ void for_each_executors_test()
 
         test_executors(par.on(exec));
         test_executors_async(par(task).on(exec));
+        
+        test_executors(unseq.on(exec));
+        test_executors_async(unseq(task).on(exec));
+        
+        test_executors(par_unseq.on(exec));
+        test_executors_async(par_unseq(task).on(exec));               
     }
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/rotate.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/rotate.cpp
@@ -9,6 +9,7 @@
 #include <hpx/local/init.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/parallel/algorithms/rotate.hpp>
+#include <hpx/executors/execution_policy.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -132,9 +133,12 @@ void test_rotate()
     test_rotate(seq, IteratorTag());
     test_rotate(par, IteratorTag());
     test_rotate(par_unseq, IteratorTag());
+    test_rotate(unseq, IteratorTag());   
 
     test_rotate_async(seq(task), IteratorTag());
     test_rotate_async(par(task), IteratorTag());
+    test_rotate_async(par_unseq(task), IteratorTag());
+    test_rotate_async(unseq(task),IteratorTag());
 }
 
 void rotate_test()

--- a/libs/core/algorithms/tests/unit/algorithms/rotate.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/rotate.cpp
@@ -9,7 +9,6 @@
 #include <hpx/local/init.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/parallel/algorithms/rotate.hpp>
-#include <hpx/executors/execution_policy.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -133,12 +132,9 @@ void test_rotate()
     test_rotate(seq, IteratorTag());
     test_rotate(par, IteratorTag());
     test_rotate(par_unseq, IteratorTag());
-    test_rotate(unseq, IteratorTag());   
 
     test_rotate_async(seq(task), IteratorTag());
     test_rotate_async(par(task), IteratorTag());
-    test_rotate_async(par_unseq(task), IteratorTag());
-    test_rotate_async(unseq(task),IteratorTag());
 }
 
 void rotate_test()
@@ -282,9 +278,13 @@ void test_rotate_exception()
     test_rotate_exception(IteratorTag());
     test_rotate_exception(seq, IteratorTag());
     test_rotate_exception(par, IteratorTag());
+    test_rotate_exception(unseq, IteratorTag());
+    test_rotate_exception(par_unseq, IteratorTag());
 
     test_rotate_exception_async(seq(task), IteratorTag());
     test_rotate_exception_async(par(task), IteratorTag());
+    test_rotate_exception_async(unseq(task), IteratorTag());
+    test_rotate_exception_async(par_unseq(task), IteratorTag());
 }
 
 void rotate_exception_test()
@@ -423,9 +423,13 @@ void test_rotate_bad_alloc()
     test_rotate_bad_alloc(IteratorTag());
     test_rotate_bad_alloc(seq, IteratorTag());
     test_rotate_bad_alloc(par, IteratorTag());
+    test_rotate_bad_alloc(unseq, IteratorTag());
+    test_rotate_bad_alloc(par_unseq, IteratorTag());
 
     test_rotate_bad_alloc_async(seq(task), IteratorTag());
     test_rotate_bad_alloc_async(par(task), IteratorTag());
+    test_rotate_bad_alloc_async(unseq(task), IteratorTag());
+    test_rotate_bad_alloc_async(par_unseq(task), IteratorTag());
 }
 
 void rotate_bad_alloc_test()

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -30,10 +30,10 @@
 namespace hpx { namespace execution {
 
     ///////////////////////////////////////////////////////////////////////////
-    /// \cond NOINTERNAL
+    /// Default sequential execution policy object.
     inline constexpr task_policy_tag task{};
+
     inline constexpr non_task_policy_tag non_task{};
-    /// \endcond
 
     namespace detail {
         template <typename T, typename Enable = void>
@@ -41,20 +41,12 @@ namespace hpx { namespace execution {
         {
         };
 
-        // some of the executions policies expose a dummy implementation of the
-        // operator()(task_policy_tag), this make sure that the returned policy
-        // is actually supporting asynchronous execution
-
-        // different versions of clang-format disagree
-        // clang-format off
         template <typename T>
         struct has_async_execution_policy<T,
             std::void_t<decltype(std::declval<std::decay_t<T>>()(task))>>
-          : hpx::is_async_execution_policy<
-                decltype(std::declval<std::decay_t<T>>()(task))>
+          : std::true_type
         {
         };
-        // clang-format on
 
         template <typename T>
         inline constexpr bool has_async_execution_policy_v =
@@ -1302,6 +1294,278 @@ namespace hpx { namespace execution {
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    /// The class parallel_unsequenced_task_policy is an execution policy type
+    /// used as a unique type to disambiguate parallel algorithm overloading
+    /// and indicate that a parallel algorithm's execution may be parallelized
+    /// and vectorized.
+    struct parallel_unsequenced_task_policy
+    {
+        /// The type of the executor associated with this execution policy
+        using executor_type = parallel_executor;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        using executor_parameters_type =
+            parallel::execution::extract_executor_parameters<
+                executor_type>::type;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        using execution_category = parallel_execution_tag;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type =
+                parallel_unsequenced_task_policy_shim<Executor_, Parameters_>;
+        };
+
+        /// \cond NOINTERNAL
+        constexpr parallel_unsequenced_task_policy() = default;
+        /// \endcond
+
+        /// Create a new parallel_unsequenced_task_policy referencing a chunk 
+        ///size.
+        /// \param tag         [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_task_policy
+        ///
+        constexpr parallel_unsequenced_task_policy operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create  a new non task parallel policy from itself
+        ///
+        /// \returns The non task parallel_unsequenced_policy
+        ///
+        inline constexpr decltype(auto) operator()(
+            non_task_policy_tag /*tag*/) const;
+
+        /// Create a new parallel_unsequenced_task_policy referencing an 
+        /// executor and a chunk size.
+        ///
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
+        ///
+        /// \returns The new parallel_unsequenced_task_policy 
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
+        {
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_task_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_task_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor()
+        {
+            return exec_;
+        }
+        /// Return the associated executor object.
+        constexpr executor_type const& executor() const
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters()
+        {
+            return params_;
+        }
+        /// Return the associated executor parameters object.
+        constexpr executor_parameters_type const& parameters() const
+        {
+            return params_;
+        }
+
+    private:
+        friend struct hpx::parallel::execution::create_rebound_policy_t;
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        constexpr void serialize(Archive&, const unsigned int)
+        {
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// The class parallel_unsequenced_task_policy_shim is an execution policy 
+    /// type used as a unique type to disambiguate parallel algorithm 
+    /// overloading and indicate that a parallel algorithm's execution may be 
+    /// parallelized and vectorized.
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_task_policy_shim
+    {
+        /// The type of the executor associated with this execution policy
+        using executor_type = std::decay_t<Executor>;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        using executor_parameters_type = std::decay_t<Parameters>;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        using execution_category =
+            typename hpx::traits::executor_execution_category<
+                executor_type>::type;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type =
+                parallel_unsequenced_task_policy_shim<Executor_, Parameters_>;
+        };
+
+        /// Create a new parallel_unsequenced_task_policy_shim referencing a  
+        /// chunk size.
+        /// \param tag         [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_task_policy
+        ///
+        constexpr parallel_unsequenced_task_policy_shim operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create  a new non task parallel unsequenced policy from itself
+        ///
+        /// \returns The non task parallel_unsequenced_policy_shim
+        ///
+        inline constexpr decltype(auto) operator()(
+            non_task_policy_tag /*tag*/) const;
+
+        /// Create a new parallel_unsequenced_task_policy_shim referencing an 
+        /// executor and a chunk size.
+        ///
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
+        ///
+        /// \returns The new parallel_unsequenced_task_policy_shim 
+        ///
+        template <typename Executor_>
+        constexpr decltype(auto) on(Executor&& exec) const
+        {
+            using executor_type = std::decay_t<Executor_>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor_, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_task_policy_shim  from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_task_policy_shim
+        ///
+        template <typename... Parameters_>
+        constexpr decltype(auto) with(Parameters_&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters_, params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor()
+        {
+            return exec_;
+        }
+        /// Return the associated executor object.
+        constexpr executor_type const& executor() const
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters()
+        {
+            return params_;
+        }
+        /// Return the associated executor parameters object.
+        constexpr executor_parameters_type const& parameters() const
+        {
+            return params_;
+        }
+
+    private:
+        friend struct hpx::parallel::execution::create_rebound_policy_t;
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        constexpr void serialize(Archive& ar, const unsigned int)
+        {
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     /// The class parallel_unsequenced_policy is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
     /// and indicate that a parallel algorithm's execution may be parallelized
@@ -1321,24 +1585,35 @@ namespace hpx { namespace execution {
         /// policy.
         using execution_category = parallel_execution_tag;
 
-        /// Rebind the type of executor used by this execution policy.
-        template <typename Executor, typename Parameters>
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
         struct rebind
         {
             /// The type of the rebound execution policy
-            using type = parallel_unsequenced_policy;
+            using type =
+                parallel_unsequenced_policy_shim<Executor_, Parameters_>;
         };
 
         /// \cond NOINTERNAL
         constexpr parallel_unsequenced_policy() = default;
-
-        template <typename Executor, typename Parameters>
-        constexpr parallel_unsequenced_policy(Executor&&, Parameters&&) noexcept
-        {
-        }
         /// \endcond
 
-        /// Create a new non task policy from itself
+        /// Create a new parallel_unsequenced_policy referencing a chunk size.
+        ///
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        constexpr parallel_unsequenced_task_policy operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return parallel_unsequenced_task_policy();
+        }
+
+        /// Create  a new parallel_unsequenced_policy from itself
         ///
         /// \returns The non task parallel unsequenced policy
         ///
@@ -1347,13 +1622,48 @@ namespace hpx { namespace execution {
             return *this;
         }
 
-        /// Create a new task policy from itself
+        /// Create a new parallel_unsequenced_policy referencing an executor and
+        /// a chunk size.
         ///
-        /// \returns The task parallel unsequenced policy
+        /// \param exec         [in] The executor to use for the execution of
+        ///                     the parallel algorithm the returned execution
+        ///                     policy is used with
         ///
-        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
         {
-            return *this;
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
         }
 
     public:
@@ -1396,7 +1706,172 @@ namespace hpx { namespace execution {
     /// Default vector execution policy object.
     inline constexpr parallel_unsequenced_policy par_unseq{};
 
-   
+    /// The class parallel_unsequenced_policy_shim is an execution policy type
+    /// used as a unique type to disambiguate parallel algorithm overloading
+    /// and indicate that a parallel algorithm's execution may be parallelized.
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_policy_shim
+    {
+        /// The type of the executor associated with this execution policy
+        using executor_type = std::decay_t<Executor>;
+
+        /// The type of the associated executor parameters object which is
+        /// associated with this execution policy
+        using executor_parameters_type = std::decay_t<Parameters>;
+
+        /// The category of the execution agents created by this execution
+        /// policy.
+        using execution_category =
+            typename hpx::traits::executor_execution_category<
+                executor_type>::type;
+
+        /// Rebind the type of executor used by this execution policy. The
+        /// execution category of Executor shall not be weaker than that of
+        /// this execution policy
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type =
+                parallel_unsequenced_policy_shim<Executor_, Parameters_>;
+        };
+
+        /// Create a new parallel_unsequenced_task_policy referencing a chunk
+        /// size.
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
+        ///
+        /// \returns The new parallel_unsequenced_task_policy_shim
+        ///
+        constexpr parallel_unsequenced_policy_shim<Executor, Parameters>
+        operator()(task_policy_tag /* tag */) const
+        {
+            return parallel_unsequenced_policy_shim<Executor, Parameters>(
+                exec_, params_);
+        }
+
+        /// Create a new parallel_policy from itself
+        ///
+        /// \param tag         [in] Specify that the corresponding asynchronous
+        ///                    execution policy should be used
+        ///
+        /// \returns The new parallel_policy
+        ///
+        constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
+        {
+            return *this;
+        }
+
+        /// Create a new parallel_unsequenced_policy from the given
+        /// executor
+        ///
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
+        ///
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_policy
+        ///
+        template <typename Executor_>
+        constexpr decltype(auto) on(Executor_&& exec) const
+        {
+            using executor_type = std::decay_t<Executor_>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor_, exec), parameters());
+        }
+
+        /// Create a new parallel_unsequenced_policy_shim from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor_parameters<Parameters>::value is true
+        ///
+        /// \returns The new parallel_unsequenced_policy_shim
+        ///
+        template <typename... Parameters_>
+        constexpr decltype(auto) with(Parameters_&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters_, params)...));
+        }
+
+    public:
+        /// Return the associated executor object.
+        executor_type& executor()
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor object.
+        constexpr executor_type const& executor() const
+        {
+            return exec_;
+        }
+
+        /// Return the associated executor parameters object.
+        executor_parameters_type& parameters()
+        {
+            return params_;
+        }
+
+        /// Return the associated executor parameters object.
+        constexpr executor_parameters_type const& parameters() const
+        {
+            return params_;
+        }
+
+        /// \cond NOINTERNAL
+        template <typename Dependent = void,
+            typename Enable =
+                std::enable_if_t<std::is_constructible<Executor>::value &&
+                        std::is_constructible<Parameters>::value,
+                    Dependent>>
+        constexpr parallel_unsequenced_policy_shim()
+        {
+        }
+
+        template <typename Executor_, typename Parameters_>
+        constexpr parallel_unsequenced_policy_shim(
+            Executor_&& exec, Parameters_&& params)
+          : exec_(HPX_FORWARD(Executor_, exec))
+          , params_(HPX_FORWARD(Parameters_, params))
+        {
+        }
+
+    private:
+        friend struct hpx::parallel::execution::create_rebound_policy_t;
+        friend class hpx::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive& ar, const unsigned int)
+        {
+            // clang-format off
+            ar & exec_ & params_;
+            // clang-format on
+        }
+
+    private:
+        executor_type exec_;
+        executor_parameters_type params_;
+        /// \endcond
+    };
+    
     ///////////////////////////////////////////////////////////////////////////
     /// The class unsequenced_task_policy is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading
@@ -1427,29 +1902,81 @@ namespace hpx { namespace execution {
         /// \cond NOINTERNAL
         constexpr unsequenced_task_policy() = default;
                    
-        template <typename Executor, typename Parameters>
-        constexpr unsequenced_task_policy(Executor&&, Parameters&&) noexcept
-        {
-        }
-        /// \endcond
+        // template <typename Executor, typename Parameters>
+        // constexpr unsequenced_task_policy(Executor&&, Parameters&&) noexcept
+        // {
+        // }
+        // /// \endcond 
 
-        /// Create a new non task policy from itself
+        /// Create a new unsequenced_task_policy from itself
         ///
-        /// \returns The non task unsequenced task policy
+        /// \param tag          [in] Specify that the corresponding asynchronous
+        ///                     execution policy should be used
         ///
-        constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
+        /// \returns The new unsequenced_task_policy
+        ///
+        constexpr unsequenced_task_policy const& operator()(
+            task_policy_tag /* tag */) const
         {
             return *this;
         }
 
-        /// Create a new task policy from itself
+        /// Create a corresponding non task policy for this task policy
         ///
-        /// \returns The task unsequenced task policy
+        /// \returns The non task unseqeuential policy
         ///
-        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        inline constexpr decltype(auto) operator()(
+            non_task_policy_tag /*tag*/) const;
+
+        /// Create a new unsequenced_task_policy from the given
+        /// executor
+        ///
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
+        ///
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new unsequenced_task_policy
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
         {
-            return *this;
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
         }
+
+        /// Create a new unsequenced_task_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: all parameters are executor_parameters,
+        ///                 different parameter types can't be duplicated
+        ///
+        /// \returns The new unsequenced_task_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
+        }   
 
     public:
         /// Return the associated executor object.
@@ -1488,39 +2015,6 @@ namespace hpx { namespace execution {
         executor_parameters_type params_;
     };
 
-    constexpr decltype(auto) sequenced_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return seq.on(executor()).with(parameters());
-    }
-
-    constexpr decltype(auto) parallel_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return par.on(executor()).with(parameters());
-    }
-
-    // different versions of clang-format disagree
-    // clang-format off
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-    sequenced_task_policy_shim<Executor, Parameters>::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return sequenced_task_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
-
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-    parallel_task_policy_shim<Executor, Parameters>::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return parallel_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
 
     /// Extension: The class unsequenced_task_policy_shim is an
     /// execution policy type used as a unique type to disambiguate parallel
@@ -1561,7 +2055,7 @@ namespace hpx { namespace execution {
         /// \param tag          [in] Specify that the corresponding asynchronous
         ///                     execution policy should be used
         ///
-        /// \returns The new unsequenced_task_policy
+        /// \returns The new unsequenced_task_policy_shim
         ///
         constexpr unsequenced_task_policy_shim const& operator()(
             task_policy_tag /* tag */) const
@@ -1571,12 +2065,12 @@ namespace hpx { namespace execution {
 
         /// Create a corresponding non task policy for this task policy
         ///
-        /// \returns The non task seqeuential shim policy
+        /// \returns The non task seqeuential policy 
         ///
         inline constexpr decltype(auto) operator()(
             non_task_policy_tag /*tag*/) const;
 
-        /// Create a new unsequenced_task_policy from the given
+        /// Create a new unsequenced_task_policy_shim from the given
         /// executor
         ///
         /// \tparam Executor    The type of the executor to associate with this
@@ -1588,7 +2082,7 @@ namespace hpx { namespace execution {
         ///
         /// \note Requires: is_executor<Executor>::value is true
         ///
-        /// \returns The new unsequenced_task_policy
+        /// \returns The new unsequenced_task_policy_shim
         ///
         template <typename Executor_>
         constexpr decltype(auto) on(Executor_&& exec) const
@@ -1661,7 +2155,7 @@ namespace hpx { namespace execution {
         }
 
         template <typename Executor_, typename Parameters_>
-        constexpr sequenced_task_policy_shim(
+        constexpr unsequenced_task_policy_shim(
             Executor_&& exec, Parameters_&& params)
           : exec_(HPX_FORWARD(Executor_, exec))
           , params_(HPX_FORWARD(Parameters_, params))
@@ -1705,9 +2199,32 @@ namespace hpx { namespace execution {
         /// policy.
         using execution_category = sequenced_execution_tag;
 
+        /// Rebind the type of executor used by this execution policy.
+        template <typename Executor_, typename Parameters_>
+        struct rebind
+        {
+            /// The type of the rebound execution policy
+            using type = unsequenced_task_policy_shim<Executor_, Parameters_>;
+        };
+
         /// \cond NOINTERNAL
         constexpr unsequenced_policy() = default;
-        /// \endcond
+
+        // template <typename Executor, typename Parameters>
+        // constexpr unsequenced_policy(Executor&&, Parameters&&) noexcept  
+        // {
+        // }
+        // /// \endcond
+
+        /// Create a new unsequenced_task_policy
+        ///
+        /// \returns The new unsequenced_task_policy
+        ///
+        constexpr unsequenced_task_policy operator()(
+            task_policy_tag /*tag*/) const
+        {
+            return unsequenced_task_policy();
+        }
 
         /// Create a new non task policy from itself
         ///
@@ -1718,13 +2235,54 @@ namespace hpx { namespace execution {
             return *this;
         }
 
-        /// Create a new task policy from itself
+        /// Create a new unsequenced_policy from the given
+        /// executor
         ///
-        /// \returns The task unsequenced policy
+        /// \tparam Executor    The type of the executor to associate with this
+        ///                     execution policy.
         ///
-        constexpr decltype(auto) operator()(task_policy_tag /*tag*/) const
+        /// \param exec         [in] The executor to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: is_executor<Executor>::value is true
+        ///
+        /// \returns The new unsequenced_policy
+        ///
+        template <typename Executor>
+        constexpr decltype(auto) on(Executor&& exec) const
         {
-            return *this;
+            using executor_type = std::decay_t<Executor>;
+
+            static_assert(hpx::traits::is_executor_any<executor_type>::value,
+                "hpx::traits::is_executor_any<Executor>::value");
+
+            return hpx::parallel::execution::create_rebound_policy(
+                *this, HPX_FORWARD(Executor, exec), parameters());
+        }
+
+        /// Create a new unsequenced_policy from the given
+        /// execution parameters
+        ///
+        /// \tparam Parameters  The type of the executor parameters to
+        ///                     associate with this execution policy.
+        ///
+        /// \param params       [in] The executor parameters to use for the
+        ///                     execution of the parallel algorithm the
+        ///                     returned execution policy is used with.
+        ///
+        /// \note Requires: all parameters are executor_parameters,
+        ///                 different parameter types can't be duplicated
+        ///
+        /// \returns The new unsequenced_policy
+        ///
+        template <typename... Parameters>
+        constexpr decltype(auto) with(Parameters&&... params) const
+        {
+            return hpx::parallel::execution::create_rebound_policy(*this,
+                executor(),
+                parallel::execution::join_executor_parameters(
+                    HPX_FORWARD(Parameters, params)...));
         }
 
     public:
@@ -1766,38 +2324,6 @@ namespace hpx { namespace execution {
 
     /// Default vector execution policy object.
     inline constexpr unsequenced_policy unseq{};
-
-    constexpr decltype(auto) sequenced_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return seq.on(executor()).with(parameters());
-    }
-
-    constexpr decltype(auto) parallel_task_policy::operator()(
-        non_task_policy_tag /*tag*/) const
-    {
-        return par.on(executor()).with(parameters());
-    }
-
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-        sequenced_task_policy_shim<Executor, Parameters>::operator()(
-            non_task_policy_tag /*tag*/) const
-    {
-        return sequenced_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
-
-    template <typename Executor, typename Parameters>
-    constexpr decltype(auto)
-        parallel_task_policy_shim<Executor, Parameters>::operator()(
-            non_task_policy_tag /*tag*/) const
-    {
-        return parallel_policy_shim<Executor, Parameters>{}
-            .on(executor())
-            .with(parameters());
-    }
 
     /// The class unsequenced_policy is an execution policy type used
     /// as a unique type to disambiguate parallel algorithm overloading and
@@ -1844,7 +2370,7 @@ namespace hpx { namespace execution {
 
         /// Create a new unsequenced_policy from itself.
         ///
-        /// \returns The new unsequenced_policy_shim
+        /// \returns The new non task unsequenced_policy_shim
         ///
         constexpr decltype(auto) operator()(non_task_policy_tag /*tag*/) const
         {
@@ -1960,12 +2486,81 @@ namespace hpx { namespace execution {
         executor_parameters_type params_;
         /// \endcond
     };
+
+    /////////////////////////////////////////////////////////////////
+    constexpr decltype(auto) sequenced_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return seq.on(executor()).with(parameters()); 
+    }
+
+    constexpr decltype(auto) parallel_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return par.on(executor()).with(parameters());
+    }
+
+    // different versions of clang-format disagree
+    // clang-format off
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    sequenced_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return sequenced_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
+
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    parallel_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return parallel_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
+    ////////////////////////////////////////////////////////////////
+    constexpr decltype(auto) unsequenced_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return unseq.on(executor()).with(parameters()); 
+    }
+
+    constexpr decltype(auto) parallel_unsequenced_task_policy::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return par_unseq.on(executor()).with(parameters());
+    }
+
+    // different versions of clang-format disagree
+    // clang-format off
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    unsequenced_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return unsequenced_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
+
+    template <typename Executor, typename Parameters>
+    constexpr decltype(auto)
+    parallel_unsequenced_task_policy_shim<Executor, Parameters>::operator()(
+        non_task_policy_tag /*tag*/) const
+    {
+        return parallel_unsequenced_task_policy_shim<Executor, Parameters>{}
+            .on(executor())
+            .with(parameters());
+    }
     // clang-format on
 }}    // namespace hpx::execution
 
 namespace hpx { namespace detail {
 
-    ///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////
     // Allow to detect execution policies which were created as a result
     // of a rebind operation. This information can be used to inhibit the
     // construction of a generic execution_policy from any of the rebound
@@ -1998,7 +2593,35 @@ namespace hpx { namespace detail {
     {
     };
 
-    ///////////////////////////////////////////////////////////////////////////
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::unsequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<
+        hpx::execution::parallel_unsequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_rebound_execution_policy<hpx::execution::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    ////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
     template <>
     struct is_execution_policy<hpx::execution::parallel_policy> : std::true_type
@@ -2018,8 +2641,22 @@ namespace hpx { namespace detail {
     {
     };
 
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::parallel_unsequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
     template <>
     struct is_execution_policy<hpx::execution::unsequenced_policy>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::unsequenced_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -2063,6 +2700,32 @@ namespace hpx { namespace detail {
       : std::true_type
     {
     };
+
+    template <>
+    struct is_execution_policy<hpx::execution::unsequenced_task_policy>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<
+        hpx::execution::unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_execution_policy<hpx::execution::parallel_unsequenced_task_policy>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_execution_policy<hpx::execution::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
@@ -2086,6 +2749,13 @@ namespace hpx { namespace detail {
     {
     };
 
+    template <typename Executor, typename Parameters>
+    struct is_parallel_execution_policy<
+        hpx::execution::parallel_unsequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
     template <>
     struct is_parallel_execution_policy<hpx::execution::parallel_task_policy>
       : std::true_type
@@ -2095,6 +2765,19 @@ namespace hpx { namespace detail {
     template <typename Executor, typename Parameters>
     struct is_parallel_execution_policy<
         hpx::execution::parallel_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_parallel_execution_policy<
+        hpx::execution::parallel_unsequenced_task_policy> : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_parallel_execution_policy<hpx::execution::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
       : std::true_type
     {
     };
@@ -2133,6 +2816,26 @@ namespace hpx { namespace detail {
       : std::true_type
     {
     };
+
+    template <typename Executor, typename Parameters>
+    struct is_sequenced_execution_policy<
+        hpx::execution::unsequenced_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_sequenced_execution_policy<
+        hpx::execution::unsequenced_task_policy> : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_sequenced_execution_policy<
+        hpx::execution::unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
     /// \endcond
 
     ///////////////////////////////////////////////////////////////////////////
@@ -2163,5 +2866,30 @@ namespace hpx { namespace detail {
     {
     };
 
+    template <>
+    struct is_async_execution_policy<hpx::execution::unsequenced_task_policy>
+      : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_async_execution_policy<
+        hpx::execution::unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_async_execution_policy<
+        hpx::execution::parallel_unsequenced_task_policy> : std::true_type
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_async_execution_policy<hpx::execution::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
+      : std::true_type
+    {
+    };
     /// \endcond
 }}    // namespace hpx::detail

--- a/libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp
@@ -33,15 +33,24 @@ namespace hpx { namespace execution {
 
     template <typename Executor, typename Parameters>
     struct parallel_task_policy_shim;
+
     struct unsequenced_task_policy;
 
     template <typename Executor, typename Parameters>
     struct unsequenced_task_policy_shim;
 
-    struct parallel_unsequenced_policy;
-
     struct unsequenced_policy;
 
     template <typename Executor, typename Parameters>
     struct unsequenced_policy_shim;
+
+    struct parallel_unsequenced_task_policy;
+    
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_task_policy_shim;
+
+    struct parallel_unsequenced_policy;
+    
+    template <typename Executor, typename Parameters>
+    struct parallel_unsequenced_policy_shim;
 }}    // namespace hpx::execution


### PR DESCRIPTION
 ### 1. TASK:
**Add missing policies :**

>         unsequenced_task_policy;
>         unsequenced_task_policy_shim;
>         unsequenced_policy;
>         unsequenced_policy_shim;
>         parallel_unsequenced_task_policy;
>         parallel_unsequenced_task_policy_shim;
>         parallel_unsequenced_policy;
>         parallel_unsequenced_policy_shim;

**Add them into `detail namespace` under different conditions**
**Add test for unseq/par_unseq in rotate.cpp & foreach.cpp & algorithms/foreach_executor.cpp**

### 2. Questions:
**Curiosity:**
In **`foreach_executors.cpp`** file, these two lines[foreach_executors_L54/55](https://github.com/STEllAR-GROUP/hpx/blob/master/libs/core/algorithms/tests/unit/algorithms/foreach_executors.cpp#L54-L55) should be here?
If it is correct, this means that only if the policy is able to execute in sequence, it can be written here.
So par_unseq should also be added in `sequenced_executor` part.

**My Thoughts:** any policy has the chance to be downgraded to sequential, then we can place them here.

**3. Task: add exceptions  implement for 6 new policies to handle local exceptions.hpp**
        `after that, add tests in rotate.cpp to test if that works`